### PR TITLE
Sign Up Page To Login Page w/ No Account Created

### DIFF
--- a/chatApp/src/main/java/org/chatapp/SceneController.java
+++ b/chatApp/src/main/java/org/chatapp/SceneController.java
@@ -63,4 +63,11 @@ public class SceneController {
         stage.show();
     }
 
+    public void signUpPageToLoginPageNoAccountCreated(ActionEvent event) throws IOException {
+        root = FXMLLoader.load(Objects.requireNonNull(getClass().getResource("LoginPage.fxml")));
+        stage = (Stage)((Node)event.getSource()).getScene().getWindow();
+        stage.getScene().setRoot(root);
+        stage.show();
+    }
+
 }

--- a/chatApp/src/main/resources/org/chatapp/SignUpPage.fxml
+++ b/chatApp/src/main/resources/org/chatapp/SignUpPage.fxml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Hyperlink?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.PasswordField?>
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane prefHeight="700.0" prefWidth="1100.0" style="-fx-background-color: #1ba4bf;" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.chatapp.SceneController">
+<AnchorPane onMouseClicked="#signUpPageToLoginPageNoAccountCreated" prefHeight="700.0" prefWidth="1100.0" style="-fx-background-color: #1ba4bf;" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.chatapp.SceneController">
    <children>
       <Label blendMode="SRC_ATOP" layoutX="424.0" layoutY="53.0" text="BU BUDDY">
          <font>
@@ -53,6 +54,7 @@
                </children>
             </AnchorPane>
             <Label fx:id="welcomeText1" />
+            <Hyperlink layoutX="290.0" layoutY="374.0" onAction="#signUpPageToLoginPageNoAccountCreated" text="Already have an account? Log in here." />
          </children>
       </AnchorPane>
    </children>


### PR DESCRIPTION
Allows user to navigate to and from the sign up page without having to close the app and relaunch or create an account via hyperlinked text "Already have an account? Log in here."